### PR TITLE
Install CLI as `baml` with `baml-cli` symlink for back-compat

### DIFF
--- a/Formula/baml.rb
+++ b/Formula/baml.rb
@@ -24,10 +24,12 @@ class Baml < Formula
   end
 
   def install
-    bin.install "baml-cli"
+    bin.install "baml-cli" => "baml"
+    bin.install_symlink "baml" => "baml-cli"
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/baml --version")
     assert_match version.to_s, shell_output("#{bin}/baml-cli --version")
   end
 end

--- a/scripts/update-baml-formula.py
+++ b/scripts/update-baml-formula.py
@@ -124,10 +124,12 @@ def render_formula(version: str, assets: dict[str, dict[str, str]]) -> str:
   end
 
   def install
-    bin.install "baml-cli"
+    bin.install "baml-cli" => "baml"
+    bin.install_symlink "baml" => "baml-cli"
   end
 
   test do
+    assert_match version.to_s, shell_output("#{{bin}}/baml --version")
     assert_match version.to_s, shell_output("#{{bin}}/baml-cli --version")
   end
 end

--- a/tests/test_update_baml_formula.py
+++ b/tests/test_update_baml_formula.py
@@ -60,8 +60,10 @@ class UpdateFormulaTests(unittest.TestCase):
     def test_migrates_stale_legacy_formula(self) -> None:
         result, formula = self.run_update('url "https://github.com/GlooHQ/baml"\nbin.install "baml"\nversion "0.19.0"\n', payload())
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn('version "0.11.0-alpha.1842"', formula.read_text())
-        self.assertIn('bin.install "baml-cli"', formula.read_text())
+        rendered = formula.read_text()
+        self.assertIn('version "0.11.0-alpha.1842"', rendered)
+        self.assertIn('bin.install "baml-cli" => "baml"', rendered)
+        self.assertIn('bin.install_symlink "baml" => "baml-cli"', rendered)
 
     def test_same_version_unchanged_is_noop(self) -> None:
         first, formula = self.run_update(None, payload())


### PR DESCRIPTION
## Summary

- Rename the installed binary from `baml-cli` to `baml` so `brew install baml` puts a `baml` on PATH (matches the formula name and what users expect to type).
- Add a `bin/baml-cli` symlink to `bin/baml` so existing scripts and docs that reference `baml-cli` keep working — single binary on disk, two names.
- Update `scripts/update-baml-formula.py` and `tests/test_update_baml_formula.py` in lockstep so the next dispatch from `BoundaryML/baml`'s release workflow doesn't revert the change.

The upstream tarball still ships a file named `baml-cli` (set by `[[bin]] name = "baml-cli"` in `baml_language/crates/baml_cli/Cargo.toml`), so the rename is done entirely at install time using Homebrew's `bin.install "src" => "dst"` syntax. No changes needed in the BAML repo.

The legacy-detection heuristic in `update-baml-formula.py` (`'bin.install "baml"' in content`) is unaffected — `bin.install "baml-cli" => "baml"` and `bin.install_symlink "baml" => "baml-cli"` don't contain that substring (the closing quote position differs / `_symlink` breaks the prefix), so the migration path stays intact.

## Test plan

- [x] `ruby -c Formula/baml.rb` — syntax OK
- [x] `python3 -m unittest tests.test_update_baml_formula -v` — 7/7 pass
- [ ] After merge, manually test `brew install BoundaryML/baml/baml` once a new alpha dispatches and confirm both `baml --version` and `baml-cli --version` work
- [ ] Confirm `brew uninstall baml` cleanly removes both symlink and binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)